### PR TITLE
Assign reserved CVE IDs to Advisories

### DIFF
--- a/advisories/unstable-attributes.md
+++ b/advisories/unstable-attributes.md
@@ -3,7 +3,7 @@
 <table>
   <tr><td>Affected component</td><td>Package <code>encoding/xml</code> in Go</td></tr>
   <tr><td>Affected versions</td><td>All</td></tr>
-  <tr><td>CVE-ID</td><td>TBD</td></tr>
+  <tr><td>CVE-ID</td><td>CVE-2020-29509</td></tr>
   <tr><td>Weakness</td><td>CWE-115: Misinterpretation of Input</td></tr>
   <tr><td>CVSS rating</td><td>9.8 (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H)</td></tr>
 </table>

--- a/advisories/unstable-directives.md
+++ b/advisories/unstable-directives.md
@@ -3,7 +3,7 @@
 <table>
   <tr><td>Affected component</td><td>Package <code>encoding/xml</code> in Go</td></tr>
   <tr><td>Affected versions</td><td>≤ 1.15</td></tr>
-  <tr><td>CVE-ID</td><td>TBD</td></tr>
+  <tr><td>CVE-ID</td><td>CVE-2020-29510</td></tr>
   <tr><td>Weakness</td><td>CWE-115: Misinterpretation of Input</td></tr>
   <tr><td>CVSS rating</td><td>9.8 (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H)</td></tr>
 </table>

--- a/advisories/unstable-elements.md
+++ b/advisories/unstable-elements.md
@@ -3,7 +3,7 @@
 <table>
   <tr><td>Affected component</td><td>Package <code>encoding/xml</code> in Go</td></tr>
   <tr><td>Affected versions</td><td>All</td></tr>
-  <tr><td>CVE-ID</td><td>TBD</td></tr>
+  <tr><td>CVE-ID</td><td>CVE-2020-29511</td></tr>
   <tr><td>Weakness</td><td>CWE-115: Misinterpretation of Input</td></tr>
   <tr><td>CVSS rating</td><td>9.8 (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H)</td></tr>
 </table>


### PR DESCRIPTION
#### Summary
This PR assigns reserved CVE IDs to the respective advisories. 

NOTE: These CVE IDs are reserved but not published yet. They will be published after the embargo end and should not be used somewhere public yet.
