### PR TITLE
Fix byteReader issue

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -1,0 +1,34 @@
+package validator
+
+import (
+	"bytes"
+	"compress/flate"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// flateIt takes and input string, compresses it using flate, and returns a flate.Reader() of the compressed content
+func flateIt(t *testing.T, input string) io.Reader {
+	t.Helper()
+
+	var zipped bytes.Buffer
+	w, err := flate.NewWriter(&zipped, flate.DefaultCompression)
+	require.NoError(t, err)
+
+	w.Write([]byte(input))
+	w.Close()
+
+	return flate.NewReader(&zipped)
+}
+
+func TestValidateZippedReader(t *testing.T) {
+	// wrap an innocuous "<foo></foo>" XML payload in a flate.Reader :
+	zipped := flateIt(t, `<foo></foo>`)
+
+	// Validate should not trigger an error on that Reader :
+	err := Validate(zipped)
+	assert.NoError(t, err)
+}

--- a/reader_test.go
+++ b/reader_test.go
@@ -18,8 +18,11 @@ func flateIt(t *testing.T, input string) io.Reader {
 	w, err := flate.NewWriter(&zipped, flate.DefaultCompression)
 	require.NoError(t, err)
 
-	w.Write([]byte(input))
-	w.Close()
+	_, err = w.Write([]byte(input))
+	require.NoError(t, err)
+
+	err = w.Close()
+	require.NoError(t, err)
 
 	return flate.NewReader(&zipped)
 }
@@ -30,5 +33,11 @@ func TestValidateZippedReader(t *testing.T) {
 
 	// Validate should not trigger an error on that Reader :
 	err := Validate(zipped)
-	assert.NoError(t, err)
+	assert.NoError(t, err, "Should not error on a valid XML document")
+
+	// an invalid document should still error :
+	zipped = flateIt(t, `<x::Root/>`)
+
+	err = Validate(zipped)
+	assert.Error(t, err, "Should error on an invalid XML document")
 }

--- a/validator.go
+++ b/validator.go
@@ -124,9 +124,9 @@ func (r *byteReader) ReadByte() (byte, error) {
 	var p [1]byte
 	n, err := r.r.Read(p[:])
 
-	// the doc for the io.ReadeByte interface states :
-	//   If ReadByte returns an error, no input byte was consumed, and the returned byte value is undefined
-	// so : if a byte is actually extracted from the reader, and we want to return it, we mustn't return the error
+	// The doc for the io.ByteReader interface states:
+	//   If ReadByte returns an error, no input byte was consumed, and the returned byte value is undefined.
+	// So if a byte is actually extracted from the reader, and we want to return it, we mustn't return the error.
 	if n > 0 {
 		// this byteReader is only used in the context of the Validate() function,
 		// we deliberately choose to completely ignore the error in this case.


### PR DESCRIPTION
#### Summary
This is a possible fix for issue #6 : make byteReader not return an error when it successfully read 1 byte

#### Ticket Link
Fixes https://github.com/mattermost/xml-roundtrip-validator/issues/6

