### PR TITLE
Fix tests for go1.17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.16.x', '1.17,x' ]
+        go: [ '1.16.x', '1.17.x' ]
 
     steps:
       - uses: actions/checkout@v2

--- a/reader_test.go
+++ b/reader_test.go
@@ -36,7 +36,7 @@ func TestValidateZippedReader(t *testing.T) {
 	assert.NoError(t, err, "Should not error on a valid XML document")
 
 	// an invalid document should still error :
-	zipped = flateIt(t, `<x::Root/>`)
+	zipped = flateIt(t, `<Root>]]></Root>`)
 
 	err = Validate(zipped)
 	assert.Error(t, err, "Should error on an invalid XML document")

--- a/validator_go116_test.go
+++ b/validator_go116_test.go
@@ -1,0 +1,135 @@
+//+build !go1.17
+
+package validator
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestColonsInLocalNames(t *testing.T) {
+	var err error
+
+	err = Validate(bytes.NewBufferString(`<x::Root/>`))
+	require.Error(t, err, "Should error on input with colons in the root element's name")
+	require.Equal(t, XMLRoundtripError{
+		Expected: tokenize(t, `<x::Root/>`),
+		Observed: tokenize(t, `<Root xmlns="x"/>`),
+	}, errors.Unwrap(err), "Error should contain expected token and mutation")
+
+	err = Validate(bytes.NewBufferString(`<Root><x::Element></::Element></Root>`))
+	require.Error(t, err, "Should error on input with colons in a nested tag's name")
+	require.Equal(t, XMLRoundtripError{
+		Expected: tokenize(t, `<x::Element>`),
+		Observed: tokenize(t, `<Element xmlns="x">`),
+	}, errors.Unwrap(err), "Error should contain expected token and mutation")
+
+	err = Validate(bytes.NewBufferString(`<Root><Element ::attr="foo"></Element></Root>`))
+	require.Error(t, err, "Should error on input with colons in an attribute's name")
+	require.Equal(t, XMLRoundtripError{
+		Expected: tokenize(t, `<Element ::attr="foo">`),
+		Observed: tokenize(t, `<Element attr="foo">`),
+	}, errors.Unwrap(err), "Error should contain expected token and mutation")
+
+	err = Validate(bytes.NewBufferString(`<Root></x::Element></Root>`))
+	require.Error(t, err, "Should error on input with colons in an end tag's name")
+	require.Equal(t, XMLRoundtripError{
+		Expected: tokenize(t, `</x::Element>`),
+		Observed: tokenize(t, `</Element>`),
+	}, errors.Unwrap(err), "Error should contain expected token and mutation")
+}
+
+func TestEmptyNames(t *testing.T) {
+	var err error
+
+	err = Validate(bytes.NewBufferString(`<x:>`))
+	require.Error(t, err, "Should error on start element with no local name")
+
+	err = Validate(bytes.NewBufferString(`</x:>`))
+	require.Error(t, err, "Should error on end element with no local name")
+}
+
+func TestEmptyAttributes(t *testing.T) {
+	var err error
+
+	err = Validate(bytes.NewBufferString(`<Root :="value"/>`))
+	require.Error(t, err, "Should error on input with empty attribute names")
+	require.Equal(t, XMLRoundtripError{
+		Expected: tokenize(t, `<Root :="value"/>`),
+		Observed: tokenize(t, `<Root/>`),
+	}, errors.Unwrap(err), "Error should contain expected token and mutation")
+
+	err = Validate(bytes.NewBufferString(`<Root x:="value"/>`))
+	require.Error(t, err, "Should error on input with empty attribute local names")
+	require.Equal(t, XMLRoundtripError{
+		Expected: tokenize(t, `<Root x:="value"/>`),
+		Observed: tokenize(t, `<Root/>`),
+	}, errors.Unwrap(err), "Error should contain expected token and mutation")
+
+	err = Validate(bytes.NewBufferString(`<Root xmlns="x" xmlns:="y"></Root>`))
+	require.Error(t, err, "Should error on input with empty xmlns local names")
+	require.Equal(t, XMLRoundtripError{
+		Expected: tokenize(t, `<Root xmlns="x" xmlns:="y">`),
+		Observed: tokenize(t, `<Root xmlns="x">`),
+	}, errors.Unwrap(err), "Error should contain expected token and mutation")
+
+	validXmlns := `<Root xmlns="http://example.com/"/>`
+	require.NoError(t, Validate(bytes.NewBufferString(validXmlns)), "Should pass on input with valid xmlns attributes")
+}
+
+func TestDirectives(t *testing.T) {
+	var err error
+
+	err = Validate(bytes.NewBufferString(
+		`<Root>
+			<! <<!-- -->!-->"--> " >
+			<! ">" <X/>>
+		</Root>`))
+	require.Error(t, err, "Should error on bad directive")
+	require.Equal(t, &xml.SyntaxError{Msg: io.ErrUnexpectedEOF.Error(), Line: 1},
+		errors.Unwrap(err), "Round trip should fail with unexpected EOF")
+
+	err = Validate(bytes.NewBufferString(`<Root><! <<!-- -->!-- x --> y></Root>`))
+	require.Error(t, err, "Should error on bad directive")
+	require.Equal(t, XMLRoundtripError{
+		Expected: tokenize(t, `<! <<!-- -->!-- x --> y>`),
+		Observed: tokenize(t, `<!  y>`),
+	}, errors.Unwrap(err), "Error should contain expected token and mutation")
+
+	goodDirectives := []string{
+		`<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">`,
+		`<! ">" <X/>>`,
+		`<!name <!-- comment --><nesting <more nesting>>>`,
+	}
+	for _, doc := range goodDirectives {
+		require.NoError(t, Validate(bytes.NewBufferString(doc)), "Should pass on good directives")
+	}
+}
+
+func TestValidateAll(t *testing.T) {
+	var err XMLValidationError
+
+	xmlBytes := []byte("<Root>\r\n    <! <<!-- -->!-- x --> y>\r\n    <Element ::attr=\"foo\"></x::Element>\r\n</Root>")
+	errs := ValidateAll(bytes.NewBuffer(xmlBytes))
+	require.Equal(t, 3, len(errs), "Should return three errors")
+
+	err = errs[0].(XMLValidationError)
+	require.Equal(t, int64(2), err.Line, "First error should be on line 2")
+	require.Equal(t, int64(5), err.Column, "First error should be on column 5")
+	require.Equal(t, []byte(`<! <<!-- -->!-- x --> y>`), xmlBytes[err.Start:err.End], "First error should point to the correct bytes in the original XML")
+
+	err = errs[1].(XMLValidationError)
+	require.Equal(t, int64(3), err.Line, "Second error should be on line 3")
+	require.Equal(t, int64(5), err.Column, "Second error should be on column 5")
+	require.Equal(t, []byte(`<Element ::attr="foo">`), xmlBytes[err.Start:err.End], "Second error should point to the correct bytes in the original XML")
+
+	err = errs[2].(XMLValidationError)
+	require.Equal(t, int64(3), err.Line, "Third error should be on line 3")
+	require.Equal(t, int64(27), err.Column, "Third error should be on column 27")
+	require.Equal(t, []byte(`</x::Element>`), xmlBytes[err.Start:err.End], "Third error should point to the correct bytes in the original XML")
+}

--- a/validator_go116_test.go
+++ b/validator_go116_test.go
@@ -1,4 +1,5 @@
-//+build !go1.17
+//go:build !go1.17
+// +build !go1.17
 
 package validator
 

--- a/validator_go116_test.go
+++ b/validator_go116_test.go
@@ -118,17 +118,17 @@ func TestValidateAll(t *testing.T) {
 	errs := ValidateAll(bytes.NewBuffer(xmlBytes))
 	require.Equal(t, 3, len(errs), "Should return three errors")
 
-	err = errs[0].(XMLValidationError)
+	errors.As(errs[0], &err)
 	require.Equal(t, int64(2), err.Line, "First error should be on line 2")
 	require.Equal(t, int64(5), err.Column, "First error should be on column 5")
 	require.Equal(t, []byte(`<! <<!-- -->!-- x --> y>`), xmlBytes[err.Start:err.End], "First error should point to the correct bytes in the original XML")
 
-	err = errs[1].(XMLValidationError)
+	errors.As(errs[1], &err)
 	require.Equal(t, int64(3), err.Line, "Second error should be on line 3")
 	require.Equal(t, int64(5), err.Column, "Second error should be on column 5")
 	require.Equal(t, []byte(`<Element ::attr="foo">`), xmlBytes[err.Start:err.End], "Second error should point to the correct bytes in the original XML")
 
-	err = errs[2].(XMLValidationError)
+	errors.As(errs[2], &err)
 	require.Equal(t, int64(3), err.Line, "Third error should be on line 3")
 	require.Equal(t, int64(27), err.Column, "Third error should be on column 27")
 	require.Equal(t, []byte(`</x::Element>`), xmlBytes[err.Start:err.End], "Third error should point to the correct bytes in the original XML")

--- a/validator_go117_test.go
+++ b/validator_go117_test.go
@@ -1,4 +1,5 @@
 //go:build go1.17
+// +build go1.17
 
 package validator
 

--- a/validator_go117_test.go
+++ b/validator_go117_test.go
@@ -1,4 +1,4 @@
-//+build go1.17
+//go:build go1.17
 
 package validator
 

--- a/validator_go117_test.go
+++ b/validator_go117_test.go
@@ -1,0 +1,101 @@
+//+build go1.17
+
+package validator
+
+import (
+	"bytes"
+	"encoding/xml"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestColonsInLocalNames(t *testing.T) {
+	var err error
+
+	el := tokenize(t, `<x::Root/>`).(xml.StartElement)
+	require.Equal(t, `x::Root`, el.Name.Local,
+		"encoding/xml should tokenize double colons as part of the local name")
+
+	err = Validate(bytes.NewBufferString(`<x::Root/>`))
+	require.NoError(t, err, "Should not error on input with colons in the root element's name")
+
+	err = Validate(bytes.NewBufferString(`<Root><x::Element></::Element></Root>`))
+	require.NoError(t, err, "Should error on input with colons in a nested tag's name")
+
+	err = Validate(bytes.NewBufferString(`<Root><Element ::attr="foo"></Element></Root>`))
+	require.NoError(t, err, "Should error on input with colons in an attribute's name")
+
+	err = Validate(bytes.NewBufferString(`<Root></x::Element></Root>`))
+	require.NoError(t, err, "Should error on input with colons in an end tag's name")
+}
+
+func TestEmptyNames(t *testing.T) {
+	var err error
+
+	el := tokenize(t, `<x:>`).(xml.StartElement)
+	require.Equal(t, `x:`, el.Name.Local,
+		"encoding/xml should tokenize a prefix-only name as a local name")
+
+	err = Validate(bytes.NewBufferString(`<x:>`))
+	require.NoError(t, err, "Should not error on start element with no local name")
+
+	err = Validate(bytes.NewBufferString(`</x:>`))
+	require.NoError(t, err, "Should not error on end element with no local name")
+}
+
+func TestEmptyAttributes(t *testing.T) {
+	var err error
+
+	el := tokenize(t, `<Root :="value"/>`).(xml.StartElement)
+	require.Equal(t, `:`, el.Attr[0].Name.Local,
+		"encoding/xml should tokenize an empty attribute name as a single colon")
+
+	err = Validate(bytes.NewBufferString(`<Root :="value"/>`))
+	require.NoError(t, err, "Should not error on input with empty attribute names")
+
+	err = Validate(bytes.NewBufferString(`<Root x:="value"/>`))
+	require.NoError(t, err, "Should not error on input with empty attribute local names")
+
+	err = Validate(bytes.NewBufferString(`<Root xmlns="x" xmlns:="y"></Root>`))
+	require.NoError(t, err, "Should not error on input with empty xmlns local names")
+
+	validXmlns := `<Root xmlns="http://example.com/"/>`
+	require.NoError(t, Validate(bytes.NewBufferString(validXmlns)), "Should pass on input with valid xmlns attributes")
+}
+
+func TestDirectives(t *testing.T) {
+	var err error
+
+	dir := tokenize(t, `<! x<!-- -->y>`).(xml.Directive)
+	require.Equal(t, ` x y`, string(dir), "encoding/xml should replace comments with spaces when tokenizing directives")
+
+	err = Validate(bytes.NewBufferString(
+		`<Root>
+			<! <<!-- -->!-->"--> " >
+			<! ">" <X/>>
+		</Root>`))
+	require.NoError(t, err, "Should not error on bad directive")
+
+	err = Validate(bytes.NewBufferString(`<Root><! <<!-- -->!-- x --> y></Root>`))
+	require.NoError(t, err, "Should not error on bad directive")
+
+	goodDirectives := []string{
+		`<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">`,
+		`<! ">" <X/>>`,
+		`<!name <!-- comment --><nesting <more nesting>>>`,
+	}
+	for _, doc := range goodDirectives {
+		require.NoError(t, Validate(bytes.NewBufferString(doc)), "Should pass on good directives")
+	}
+}
+
+func TestValidateAll(t *testing.T) {
+	el := tokenize(t, `<x::Root/>`).(xml.StartElement)
+	require.Equal(t, `x::Root`, el.Name.Local,
+		"encoding/xml should tokenize double colons as part of the local name")
+
+	xmlBytes := []byte("<Root>\r\n    <! <<!-- -->!-- x --> y>\r\n    <Element ::attr=\"foo\"></x::Element>\r\n</Root>")
+	errs := ValidateAll(bytes.NewBuffer(xmlBytes))
+	require.Equal(t, 0, len(errs), "Should return zero errors")
+}

--- a/validator_test.go
+++ b/validator_test.go
@@ -3,7 +3,6 @@ package validator
 import (
 	"bytes"
 	"encoding/xml"
-	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -34,121 +33,6 @@ func TestValidXML(t *testing.T) {
 	}
 }
 
-func TestColonsInLocalNames(t *testing.T) {
-	var err error
-
-	if el := tokenize(t, `<x::Root/>`).(xml.StartElement); el.Name.Local == `x::Root` {
-		t.Skip("Name parsing fixed in stdlib, skipping test") // go1.17+
-	}
-
-	err = Validate(bytes.NewBufferString(`<x::Root/>`))
-	require.Error(t, err, "Should error on input with colons in the root element's name")
-	require.Equal(t, XMLRoundtripError{
-		Expected: tokenize(t, `<x::Root/>`),
-		Observed: tokenize(t, `<Root xmlns="x"/>`),
-	}, errors.Unwrap(err), "Error should contain expected token and mutation")
-
-	err = Validate(bytes.NewBufferString(`<Root><x::Element></::Element></Root>`))
-	require.Error(t, err, "Should error on input with colons in a nested tag's name")
-	require.Equal(t, XMLRoundtripError{
-		Expected: tokenize(t, `<x::Element>`),
-		Observed: tokenize(t, `<Element xmlns="x">`),
-	}, errors.Unwrap(err), "Error should contain expected token and mutation")
-
-	err = Validate(bytes.NewBufferString(`<Root><Element ::attr="foo"></Element></Root>`))
-	require.Error(t, err, "Should error on input with colons in an attribute's name")
-	require.Equal(t, XMLRoundtripError{
-		Expected: tokenize(t, `<Element ::attr="foo">`),
-		Observed: tokenize(t, `<Element attr="foo">`),
-	}, errors.Unwrap(err), "Error should contain expected token and mutation")
-
-	err = Validate(bytes.NewBufferString(`<Root></x::Element></Root>`))
-	require.Error(t, err, "Should error on input with colons in an end tag's name")
-	require.Equal(t, XMLRoundtripError{
-		Expected: tokenize(t, `</x::Element>`),
-		Observed: tokenize(t, `</Element>`),
-	}, errors.Unwrap(err), "Error should contain expected token and mutation")
-}
-
-func TestEmptyNames(t *testing.T) {
-	var err error
-
-	if el := tokenize(t, `<x:>`).(xml.StartElement); el.Name.Local == `x:` {
-		t.Skip("Name parsing fixed in stdlib, skipping test") // go1.17+
-	}
-
-	err = Validate(bytes.NewBufferString(`<x:>`))
-	require.Error(t, err, "Should error on start element with no local name")
-
-	err = Validate(bytes.NewBufferString(`</x:>`))
-	require.Error(t, err, "Should error on end element with no local name")
-}
-
-func TestEmptyAttributes(t *testing.T) {
-	var err error
-
-	if el := tokenize(t, `<Root :="value"/>`).(xml.StartElement); el.Attr[0].Name.Local == `:` {
-		t.Skip("Name parsing fixed in stdlib, skipping test") // go1.17+
-	}
-
-	err = Validate(bytes.NewBufferString(`<Root :="value"/>`))
-	require.Error(t, err, "Should error on input with empty attribute names")
-	require.Equal(t, XMLRoundtripError{
-		Expected: tokenize(t, `<Root :="value"/>`),
-		Observed: tokenize(t, `<Root/>`),
-	}, errors.Unwrap(err), "Error should contain expected token and mutation")
-
-	err = Validate(bytes.NewBufferString(`<Root x:="value"/>`))
-	require.Error(t, err, "Should error on input with empty attribute local names")
-	require.Equal(t, XMLRoundtripError{
-		Expected: tokenize(t, `<Root x:="value"/>`),
-		Observed: tokenize(t, `<Root/>`),
-	}, errors.Unwrap(err), "Error should contain expected token and mutation")
-
-	err = Validate(bytes.NewBufferString(`<Root xmlns="x" xmlns:="y"></Root>`))
-	require.Error(t, err, "Should error on input with empty xmlns local names")
-	require.Equal(t, XMLRoundtripError{
-		Expected: tokenize(t, `<Root xmlns="x" xmlns:="y">`),
-		Observed: tokenize(t, `<Root xmlns="x">`),
-	}, errors.Unwrap(err), "Error should contain expected token and mutation")
-
-	validXmlns := `<Root xmlns="http://example.com/"/>`
-	require.NoError(t, Validate(bytes.NewBufferString(validXmlns)), "Should pass on input with valid xmlns attributes")
-}
-
-func TestDirectives(t *testing.T) {
-	var err error
-
-	if dir := tokenize(t, `<! x<!-- -->y>`).(xml.Directive); string(dir) == ` x y` {
-		t.Skip("Directive parsing fixed in stdlib, skipping test") // go1.17+
-	}
-
-	err = Validate(bytes.NewBufferString(
-		`<Root>
-			<! <<!-- -->!-->"--> " >
-			<! ">" <X/>>
-		</Root>`))
-	require.Error(t, err, "Should error on bad directive")
-	require.Equal(t, &xml.SyntaxError{Msg: io.ErrUnexpectedEOF.Error(), Line: 1},
-		errors.Unwrap(err), "Round trip should fail with unexpected EOF")
-
-	err = Validate(bytes.NewBufferString(`<Root><! <<!-- -->!-- x --> y></Root>`))
-	require.Error(t, err, "Should error on bad directive")
-	require.Equal(t, XMLRoundtripError{
-		Expected: tokenize(t, `<! <<!-- -->!-- x --> y>`),
-		Observed: tokenize(t, `<!  y>`),
-	}, errors.Unwrap(err), "Error should contain expected token and mutation")
-
-	goodDirectives := []string{
-		`<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">`,
-		`<! ">" <X/>>`,
-		`<!name <!-- comment --><nesting <more nesting>>>`,
-	}
-	for _, doc := range goodDirectives {
-		require.NoError(t, Validate(bytes.NewBufferString(doc)), "Should pass on good directives")
-	}
-}
-
 func TestUnparseableXML(t *testing.T) {
 	var err error
 
@@ -176,33 +60,6 @@ func TestUnparseableXML(t *testing.T) {
 		require.Error(t, errs[1], "Should error on unexpected ']]>' sequence")
 		require.IsType(t, &xml.SyntaxError{}, errs[1], "Error should be an &xml.SyntaxError")
 	}
-}
-
-func TestValidateAll(t *testing.T) {
-	var err XMLValidationError
-
-	if el := tokenize(t, `<x::Root/>`).(xml.StartElement); el.Name.Local == `x::Root` {
-		t.Skip("Name parsing fixed in stdlib, skipping test") // go1.17+
-	}
-
-	xmlBytes := []byte("<Root>\r\n    <! <<!-- -->!-- x --> y>\r\n    <Element ::attr=\"foo\"></x::Element>\r\n</Root>")
-	errs := ValidateAll(bytes.NewBuffer(xmlBytes))
-	require.Equal(t, 3, len(errs), "Should return three errors")
-
-	err = errs[0].(XMLValidationError)
-	require.Equal(t, int64(2), err.Line, "First error should be on line 2")
-	require.Equal(t, int64(5), err.Column, "First error should be on column 5")
-	require.Equal(t, []byte(`<! <<!-- -->!-- x --> y>`), xmlBytes[err.Start:err.End], "First error should point to the correct bytes in the original XML")
-
-	err = errs[1].(XMLValidationError)
-	require.Equal(t, int64(3), err.Line, "Second error should be on line 3")
-	require.Equal(t, int64(5), err.Column, "Second error should be on column 5")
-	require.Equal(t, []byte(`<Element ::attr="foo">`), xmlBytes[err.Start:err.End], "Second error should point to the correct bytes in the original XML")
-
-	err = errs[2].(XMLValidationError)
-	require.Equal(t, int64(3), err.Line, "Third error should be on line 3")
-	require.Equal(t, int64(27), err.Column, "Third error should be on column 27")
-	require.Equal(t, []byte(`</x::Element>`), xmlBytes[err.Start:err.End], "Third error should point to the correct bytes in the original XML")
 }
 
 func TestTokenEquals(t *testing.T) {


### PR DESCRIPTION
#### Summary
Go 1.17 contains some fixes for round-trip issues, which breaks our tests that assume the bugs are there. This PR mostly just skips the affected tests when the stdlib behaves "correctly".

#### Ticket Link
Fixes https://github.com/mattermost/xml-roundtrip-validator/issues/9
