### PR TITLE
Remove tests that are no longer relevant in go1.20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.16.x', '1.17.x', '1.20.x' ]
+        go: [ '1.19.x', '1.20.x' ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.16.x', '1.17.x' ]
+        go: [ '1.16.x', '1.17.x', '1.20.x' ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 linters:
   enable:
   - asciicheck
-  - deadcode
+  - unused
   - depguard
   - errcheck
   - errorlint

--- a/cmd/xrv.go
+++ b/cmd/xrv.go
@@ -35,13 +35,12 @@ func main() {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
 		}
 		os.Exit(1)
-	} else {
-		err := validator.Validate(f)
-		if err == nil {
-			fmt.Println("Document validated without errors")
-			os.Exit(0)
-		}
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
 	}
+	err := validator.Validate(f)
+	if err == nil {
+		fmt.Println("Document validated without errors")
+		os.Exit(0)
+	}
+	fmt.Fprintf(os.Stderr, "%v\n", err)
+	os.Exit(1)
 }

--- a/cmd/xrv.go
+++ b/cmd/xrv.go
@@ -36,7 +36,7 @@ func main() {
 		}
 		os.Exit(1)
 	}
-	err := validator.Validate(f)
+	err = validator.Validate(f)
 	if err == nil {
 		fmt.Println("Document validated without errors")
 		os.Exit(0)

--- a/validator_go120_test.go
+++ b/validator_go120_test.go
@@ -1,5 +1,5 @@
-//go:build go1.17 && !go1.20
-// +build go1.17,!go1.20
+//go:build go1.20
+// +build go1.20
 
 package validator
 
@@ -10,26 +10,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
-
-func TestColonsInLocalNames(t *testing.T) {
-	var err error
-
-	el := tokenize(t, `<x::Root/>`).(xml.StartElement)
-	require.Equal(t, `x::Root`, el.Name.Local,
-		"encoding/xml should tokenize double colons as part of the local name")
-
-	err = Validate(bytes.NewBufferString(`<x::Root/>`))
-	require.NoError(t, err, "Should not error on input with colons in the root element's name")
-
-	err = Validate(bytes.NewBufferString(`<Root><x::Element></::Element></Root>`))
-	require.NoError(t, err, "Should error on input with colons in a nested tag's name")
-
-	err = Validate(bytes.NewBufferString(`<Root><Element ::attr="foo"></Element></Root>`))
-	require.NoError(t, err, "Should error on input with colons in an attribute's name")
-
-	err = Validate(bytes.NewBufferString(`<Root></x::Element></Root>`))
-	require.NoError(t, err, "Should error on input with colons in an end tag's name")
-}
 
 func TestEmptyNames(t *testing.T) {
 	var err error
@@ -92,11 +72,7 @@ func TestDirectives(t *testing.T) {
 }
 
 func TestValidateAll(t *testing.T) {
-	el := tokenize(t, `<x::Root/>`).(xml.StartElement)
-	require.Equal(t, `x::Root`, el.Name.Local,
-		"encoding/xml should tokenize double colons as part of the local name")
-
-	xmlBytes := []byte("<Root>\r\n    <! <<!-- -->!-- x --> y>\r\n    <Element ::attr=\"foo\"></x::Element>\r\n</Root>")
+	xmlBytes := []byte("<Root>\r\n    <! <<!-- -->!-- x --> y>\r\n    <Element :attr=\"foo\"></x:Element>\r\n</Root>")
 	errs := ValidateAll(bytes.NewBuffer(xmlBytes))
 	require.Equal(t, 0, len(errs), "Should return zero errors")
 }


### PR DESCRIPTION
#### Summary
As of 1.20, Go no longer accepts multiple colons in QNames, which is the correct behavior. This means we no longer have to test using XML that contains such constructs.

Removed a failing test and altered another one to not use double colons. Added Go 1.20 to the test matrix.

#### Ticket Link
Fixes #12 
